### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,17 +30,17 @@ fn main() {
       let now = std::time::Instant::now();
       model.test(&test_images, image_height * image_width, num_test_image, &test_labels);
       let elapsed = now.elapsed();
-      println!("Test time: {:.?}" , elapsed);
+      println!("Test time: {:?}" , elapsed);
 
       let now = std::time::Instant::now();
       model.train(&train_images, image_height * image_width, num_train_images, &train_labels, &p);
       let elapsed = now.elapsed();
-      println!("Epoch training time: {:.?}", elapsed);
+      println!("Epoch training time: {:?}", elapsed);
    }
 
    let now = std::time::Instant::now();
    model.test(&test_images, image_height * image_width, num_test_image, &test_labels);
    let elapsed = now.elapsed();
-   println!("Test time: {:.?}" , elapsed);
+   println!("Test time: {:?}" , elapsed);
 
 }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.